### PR TITLE
feat: Introduced jest into the project

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -6,5 +6,6 @@ dist
 *.DS_Store
 *.env
 *.env.*
+.cursor/rules/
 tsconfig.tsbuildinfo
 

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  presets: [
+    ["@babel/preset-env", { targets: { node: "current" } }],
+    ["@babel/preset-react", { runtime: "automatic" }],
+    "@babel/preset-typescript",
+  ],
+};

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,12 @@
+/** @type {import("jest").Config} **/
+
+export default {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  moduleNameMapper: {
+    // Match your tsconfig paths if you use them
+    "^@/(.*)$": "<rootDir>/src/$1",
+    "\\.(css|less|scss|sass)$": "identity-obj-proxy",
+  },
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+};

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "npm run clean:js && tsc -b && vite build",
     "preview": "vite preview",
-    "clean:js": "node scripts/clean-js.mjs"
+    "clean:js": "node scripts/clean-js.mjs",
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@monaco-editor/react": "4.6.0",
@@ -28,14 +30,25 @@
     "zustand": "^5.0.7"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.28.0",
+    "@babel/preset-react": "^7.27.1",
+    "@babel/preset-typescript": "^7.27.1",
+    "@testing-library/jest-dom": "^6.7.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^30.0.0",
     "@types/node": "22.7.4",
     "@types/react": "18.3.8",
     "@types/react-dom": "18.3.0",
     "@vitejs/plugin-react": "4.3.1",
     "autoprefixer": "10.4.20",
+    "babel-jest": "^30.0.5",
+    "jest": "^30.0.5",
+    "jest-environment-jsdom": "^30.0.5",
     "postcss": "8.4.47",
     "shadcn-ui": "0.9.4",
     "tailwindcss": "3.4.10",
+    "ts-jest": "^29.4.1",
     "typescript": "5.6.2",
     "vite": "5.4.3"
   }

--- a/frontend/src/data/parser/parser_rules.md
+++ b/frontend/src/data/parser/parser_rules.md
@@ -1,0 +1,7 @@
+# Parser Rules
+
+Since we are using Piston api - we don't need to worry about compiling, and execution.
+
+### So why do we need a parser?
+
+> Although we are sending the code to Piston, we are going to use that code for internal purposes as well.

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,10 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: ["class"],
-  content: [
-    "./index.html",
-    "./src/**/*.{ts,tsx}",
-  ],
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
   theme: {
     extend: {
       colors: {
@@ -64,4 +61,4 @@ export default {
     },
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
This pull request sets up the frontend project for testing and modern JavaScript/TypeScript development. The most important changes are the addition of Babel and Jest configurations, updates to dependencies to support testing, and new npm scripts for running tests.

**Testing Setup**

* Added `jest.config.js` and `jest.setup.ts` to configure Jest for TypeScript and React testing, including support for CSS modules and the Testing Library. [[1]](diffhunk://#diff-64b6af65ba015c0cadc7c871d90a22800edf7316d4ff12361be6af9c8607efa3R1-R12) [[2]](diffhunk://#diff-34e77f899f3fadc810c5b05f57b15f18f56d2037c8d99ad99079f93acfa4d108R1)
* Updated `package.json` to add new test scripts (`test`, `test:watch`) and included necessary testing dependencies such as `jest`, `babel-jest`, `ts-jest`, and Testing Library packages. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L10-R12) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R33-R51)

**Build Tooling**

* Added `babel.config.js` with presets for modern JavaScript, React (automatic runtime), and TypeScript, enabling Babel-based transpilation.

**Documentation**

* Added a new parser rules documentation file at `src/data/parser/parser_rules.md` to explain the purpose of the internal parser.

**Minor Configuration Updates**

* Updated `tailwind.config.js` formatting for consistency and style. [[1]](diffhunk://#diff-8fdab0c1827a182dfaa61b1253086037a44105350409f6701c49ebe130f6705bL4-R4) [[2]](diffhunk://#diff-8fdab0c1827a182dfaa61b1253086037a44105350409f6701c49ebe130f6705bL67-R64)
* Added `.cursor/rules/` to `.gitignore` to exclude editor-specific files.